### PR TITLE
added support for login with social accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ uploaded
 static_root
 
 local_settings.py
+
+# pycharm IDE files
+.idea

--- a/ihp/__init__.py
+++ b/ihp/__init__.py
@@ -21,18 +21,12 @@
 import re
 import string
 import logging
-from django import forms
 from django.apps import AppConfig
 from django.db import models
-from django.db.models import signals
-from django.utils.datastructures import OrderedDict
-from django.contrib import messages
-from django.contrib.auth import get_user_model
-from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response, get_object_or_404, redirect
 from django.utils.translation import ugettext_lazy as _
 
 alnum_re = re.compile(r'^[a-zA-Z][A-Za-z_-]*$')
+
 
 def populate_username(first_name, last_name):
     fname = u''.join(e for e in first_name if e in string.ascii_letters or '-' == e).lower()
@@ -59,62 +53,9 @@ class IHPAppConfig(AppConfig):
         cls.add_to_class('doi', doi)
         # cls._meta.add_field(doi)
 
-    def patch_form(self, form_cls):
-        form_cls.declared_fields.pop('username', None)
-
-        extra_fields = [
-                        ('first_name',
-                         forms.CharField(required=True, min_length=2),),
-                        ('last_name',
-                         forms.CharField(required=True, min_length=2),)
-                        ]
-        fields = extra_fields + list(form_cls.declared_fields.viewitems())
-        form_cls.base_fields = form_cls.declared_fields = OrderedDict(fields)
-
-    def patch_view(self, view):
-        def generate_username(s, form):
-            c = form.cleaned_data
-            username = populate_username(c['first_name'], c['last_name'])
-            User = get_user_model()
-            from account.utils import get_user_lookup_kwargs
-            lookup_kwargs = get_user_lookup_kwargs({
-                "{username}__iexact": username
-            })
-            qs = User.objects.filter(**lookup_kwargs)
-            if not qs.exists():
-                return username
-            else:
-                lookup_kwargs = get_user_lookup_kwargs({
-                    "{username}__startswith": username
-                })
-                qs = User.objects.filter(**lookup_kwargs)
-                username += '_{}'.format((qs.count()))
-                try:
-                    User.objects.get(username__iexact=username)
-                except User.DoesNotExist:
-                    return username
-            raise forms.ValidationError(_("This username already exists."))
-
-        view.generate_username = generate_username
-
-    def on_signed_up(self, user, form, *args, **kwargs):
-        user.first_name = ''.join(e for e in form.cleaned_data['first_name'] if e in string.ascii_letters or '-' == e)
-        user.last_name = ''.join(e for e in form.cleaned_data['last_name'] if e in string.ascii_letters or '-' == e)
-        user.save()
-        form.cleaned_data['username'] = user.username
-
     def ready(self):
         from geonode.base.models import ResourceBase
-
         self.patch_resource_base(ResourceBase)
-
-        from account.forms import SignupForm
-        from account.views import SignupView
-        from account.signals import user_signed_up
-
-        self.patch_form(SignupForm)
-        self.patch_view(SignupView)
-        user_signed_up.connect(self.on_signed_up, sender=SignupForm)
 
 
 default_app_config = 'ihp.IHPAppConfig'

--- a/ihp/content/forms.py
+++ b/ihp/content/forms.py
@@ -1,15 +1,38 @@
 from django import forms
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-import account.forms
+from django.utils.datastructures import OrderedDict
+
+from allauth.account import forms as account_forms
+from allauth.socialaccount import forms as socialaccount_forms
 
 
-class SignupForm(account.forms.SignupForm):
-    first_name = forms.CharField(label=_(u'First name'))
+class UnescoLocalAccountSignupForm(account_forms.SignupForm):
 
-    last_name = forms.CharField(label=_(u'Last name'))
+    def __init__(self, *args, **kwargs):
+        super(UnescoLocalAccountSignupForm, self).__init__(*args, **kwargs)
+        _replace_username_with_first_last(self)
 
-    accept = forms.BooleanField(
-        required = True,
-        label = _(u'I agree to the IHP-WINS Terms of use')
+
+class UnescoSocialAccountSignupForm(socialaccount_forms.SignupForm):
+
+    def __init__(self, *args, **kwargs):
+        super(UnescoSocialAccountSignupForm, self).__init__(*args, **kwargs)
+        _replace_username_with_first_last(self)
+
+
+def _replace_username_with_first_last(form):
+    form.fields.pop("username")
+    fields = OrderedDict()
+    fields["first_name"] = forms.CharField(min_length=2, label=_(u"First name"))
+    fields["last_name"] = forms.CharField(min_length=2, label=_(u"Last name"))
+    for key, value in form.fields.iteritems():
+        fields[key] = value
+    terms_url = "http://ihp-wins-dev.geo-solutions.it/terms-of-use"
+    agreement_message = _(
+        "I have read and agree with the "
+        "<a href={!r} target='_blank' rel='noopener noreferrer'>"
+        "IHP-WINS Terms of use"
+        "<a>".format(terms_url)
     )
+    fields["terms_agreement"] = forms.BooleanField(label=agreement_message)
+    form.fields = fields

--- a/ihp/content/views.py
+++ b/ihp/content/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import redirect
 from django.http.response import HttpResponseNotFound
 from django.template import RequestContext
 from django.shortcuts import render_to_response
@@ -9,12 +8,6 @@ from .models import (TermsOfUse,
                      PartnerIcon,
                      FaqTopic,
                      DocumentationPage)
-from .forms import SignupForm
-import account.views
-
-
-class SignupView(account.views.SignupView):
-    form_class = SignupForm
 
 
 def terms_of_use_view(request):

--- a/ihp/settings.py
+++ b/ihp/settings.py
@@ -76,3 +76,62 @@ GROUP_MANDATORY_RESOURCES = True
 MODIFY_TOPICCATEGORY = True
 USER_MESSAGES_ALLOW_MULTIPLE_RECIPIENTS = True
 DISPLAY_WMS_LINKS = False
+ACCOUNT_FORMS = {
+    "signup": "ihp.content.forms.UnescoLocalAccountSignupForm",
+}
+
+SOCIALACCOUNT_AUTO_SIGNUP = False
+SOCIALACCOUNT_FORMS = {
+    "signup": "ihp.content.forms.UnescoSocialAccountSignupForm",
+}
+INSTALLED_APPS += (
+    'allauth.socialaccount.providers.linkedin',
+    'allauth.socialaccount.providers.facebook',
+)
+
+SOCIALACCOUNT_PROVIDERS = {
+    'linkedin': {
+        'SCOPE': [
+            'r_emailaddress',
+            'r_basicprofile',
+        ],
+        'PROFILE_FIELDS': [
+            'email-address',
+            'first-name',
+            'headline',
+            'id',
+            'industry',
+            'last-name',
+            'picture-url',
+            'positions',
+            'public-profile-url',
+            'location',
+            'specialties',
+            'summary',
+        ]
+    },
+    'facebook': {
+        'METHOD': 'oauth2',
+        'SCOPE': [
+            'email',
+            'public_profile',
+        ],
+        'FIELDS': [
+            'id',
+            'email',
+            'name',
+            'first_name',
+            'last_name',
+            'verified',
+            'locale',
+            'timezone',
+            'link',
+            'gender',
+        ]
+    },
+}
+
+SOCIALACCOUNT_PROFILE_EXTRACTORS = {
+    "facebook": "geonode.people.profileextractors.FacebookExtractor",
+    "linkedin": "geonode.people.profileextractors.LinkedInExtractor",
+}

--- a/ihp/settings.py
+++ b/ihp/settings.py
@@ -85,26 +85,26 @@ SOCIALACCOUNT_FORMS = {
     "signup": "ihp.content.forms.UnescoSocialAccountSignupForm",
 }
 INSTALLED_APPS += (
-    'allauth.socialaccount.providers.linkedin',
+    'allauth.socialaccount.providers.linkedin_oauth2',
     'allauth.socialaccount.providers.facebook',
 )
 
 SOCIALACCOUNT_PROVIDERS = {
-    'linkedin': {
+    'linkedin_oauth2': {
         'SCOPE': [
             'r_emailaddress',
             'r_basicprofile',
         ],
         'PROFILE_FIELDS': [
-            'email-address',
-            'first-name',
+            'emailAddress',
+            'firstName',
             'headline',
             'id',
             'industry',
-            'last-name',
-            'picture-url',
+            'lastName',
+            'pictureUrl',
             'positions',
-            'public-profile-url',
+            'publicProfileUrl',
             'location',
             'specialties',
             'summary',
@@ -133,5 +133,5 @@ SOCIALACCOUNT_PROVIDERS = {
 
 SOCIALACCOUNT_PROFILE_EXTRACTORS = {
     "facebook": "geonode.people.profileextractors.FacebookExtractor",
-    "linkedin": "geonode.people.profileextractors.LinkedInExtractor",
+    "linkedin_oauth2": "geonode.people.profileextractors.LinkedInExtractor",
 }

--- a/ihp/templates/account/email/email_confirmation_message.txt
+++ b/ihp/templates/account/email/email_confirmation_message.txt
@@ -1,6 +1,0 @@
-{% load i18n account_tags %}{% blocktrans with site_name=current_site.name %}A user on {{ site_name }} has created an account using this email address.
-
-To confirm this email address, go to {{ activate_url }}
-
-If you did not sign up for this site, you can ignore this message.
-{% endblocktrans %}

--- a/ihp/templates/account/email/email_confirmation_subject.txt
+++ b/ihp/templates/account/email/email_confirmation_subject.txt
@@ -1,1 +1,0 @@
-{% load i18n %}{% blocktrans with site_name=current_site.name %}Confirm email address for {{ site_name }}{% endblocktrans %}

--- a/ihp/templates/account/email/invite_user.txt
+++ b/ihp/templates/account/email/invite_user.txt
@@ -1,3 +1,0 @@
-You have been invited to sign up at {{ current_site.name }}.
-
-{{ signup_url }}

--- a/ihp/templates/account/email/invite_user_subject.txt
+++ b/ihp/templates/account/email/invite_user_subject.txt
@@ -1,1 +1,0 @@
-Create an account on {{ current_site.name }}

--- a/ihp/templates/account/email/password_change.txt
+++ b/ihp/templates/account/email/password_change.txt
@@ -1,1 +1,0 @@
-This is the email notification to confirm your password has been changed on {{ user.account.now }}.

--- a/ihp/templates/account/email/password_change_subject.txt
+++ b/ihp/templates/account/email/password_change_subject.txt
@@ -1,1 +1,0 @@
-Change password email notification

--- a/ihp/templates/account/email/password_reset.txt
+++ b/ihp/templates/account/email/password_reset.txt
@@ -1,5 +1,0 @@
-{% load i18n %}{% blocktrans with site_name=current_site.name %}You're receiving this email because you or someone else has requested a password for your user account at {{ site_name }}.
-It can be safely ignored if you did not request a password reset. Click the link below to reset your password.
-
-{{ password_reset_url }}
-{% endblocktrans %}

--- a/ihp/templates/account/email/password_reset_subject.txt
+++ b/ihp/templates/account/email/password_reset_subject.txt
@@ -1,1 +1,0 @@
-{% load i18n %}{% blocktrans with site_name=current_site.name %}[{{ site_name }}] Password reset{% endblocktrans %}

--- a/ihp/templates/account/signup.html
+++ b/ihp/templates/account/signup.html
@@ -1,39 +1,45 @@
-{% extends "geonode_base.html" %}
+{% extends "account/base.html" %}
 
 {% load url from future %}
 {% load i18n %}
 {% load bootstrap_tags %}
+{% load account socialaccount %}
 
 {% block head_title %}{% trans "Sign up" %}{% endblock %}
+{% block title %}{% trans "Sign up" %}{% endblock %}
 
-{% block body %}
-<div class="page-header">
-  <h2>{% trans "Sign up" %}</h2>
-</div>
-<div class="row">
-  <div class="col-md-8">
-  {% if ACCOUNT_OPEN_SIGNUP %}
-    <form id="signup_form" method="post" action="{% url "account_signup" %}" autocapitalize="off" class="form-horizontal"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
-      <fieldset>
-      {% csrf_token %}
-      {{ form|as_bootstrap }}
-      {% if redirect_field_value %}
-        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-      {% endif %}
-        <em style="color:red">* {% trans "Before start using this service you must carefully read and agree to the" %} <a href="/terms-of-use" target="_blank">{% trans "Terms of use" %}</a></em>
-        <div class="form-actions">
-          <button type="submit" class="btn btn-primary">{% trans "Sign up" %}</button>
+{% block body_outer %}
+    <div class="page-header">
+        <h2>{% trans "Sign up" %}</h2>
+    </div>
+    <div class="row">
+        <div class="col-md-8">
+            {% get_providers as socialaccount_providers %}
+            {% if socialaccount_providers %}
+                <p>{% blocktrans with site.name as site_name %}Sign up with one
+                    of your existing third party accounts{% endblocktrans %}</p>
+                {% include "socialaccount/snippets/provider_list.html" with process="signup" %}
+                {% include "socialaccount/snippets/login_extra.html" %}
+                <hr>
+            {% endif %}
+            <p>Create a new local account</p>
+            <form id="signup_form" method="post" action="{% url "account_signup" %}" autocapitalize="off" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+                <fieldset>
+                    {% csrf_token %}
+                    {{ form|as_bootstrap }}
+                    {% if redirect_field_value %}
+                        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+                    {% endif %}
+                    <div class="form-actions">
+                        <button type="submit" class="btn btn-primary">{% trans "Sign up" %}</button>
+                    </div>
+                </fieldset>
+            </form>
         </div>
-      </fieldset>
-    </form>
-    {% else %}
-    <p>{% trans "Sorry, registrations are not open at this time." %}</p>
-    {% endif %}
-  </div>
-  <div class="col-md-4">
-    {% include "account/_signup_sidebar.html" %}
-  </div>
-</div>
+        <div class="col-md-4">
+            {% include "account/_signup_sidebar.html" %}
+        </div>
+    </div>
 {% endblock %}
 
 {% block extra_script %}
@@ -66,3 +72,5 @@
     });
   </script>
 {% endblock %}
+
+

--- a/ihp/templates/base.html
+++ b/ihp/templates/base.html
@@ -1,5 +1,6 @@
 {% load i18n avatar_tags %}
 {% load user_messages_tags %}
+{% load account socialaccount %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -200,9 +201,15 @@
           <form class="form-signin" role="form" action="{% url "account_login" %}?next={{ request.path }}" method="post">
             <div class="modal-body">
               {% csrf_token %}
+              {%  get_providers as socialaccount_providers %}
+              {% if socialaccount_providers %}
+                  {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+                  {% include "socialaccount/snippets/login_extra.html" %}
+                  <hr>
+              {% endif %}
               <div class="form-group">
                 <label for="id_username" class="sr-only">{% trans "Username" %}:</label>
-                <input id="id_username" class="form-control" name="username" placeholder="{% trans "Username" %}" type="text" />
+                <input id="id_username" class="form-control" name="login" placeholder="{% trans "Username" %}" type="text" />
               </div>
               <div class="form-group">
                 <label for="id_password" class="sr-only">{% trans "Password" %}:</label>
@@ -242,7 +249,7 @@
               {% endif %}
               {% if user.is_superuser %}
               <li><a href="{% url "services" %}"><i class="fa fa-globe"></i> {% trans "Remote Services" %}</a></li>
-              <li><a href="{% url "account_invite_user" %}"><i class="fa fa-edit"></i> {% trans "Invite User" %}</a></li>
+              <li><a href="{% url "invitations:send-invite" %}"><i class="fa fa-edit"></i> {% trans "Invite User" %}</a></li>
               <li class="modal-divider"></li>
               <li><a href="{{ GEOSERVER_BASE_URL }}"><i class="fa fa-gears"></i> {% trans "GeoServer" %}</a></li>
               {% endif %}

--- a/ihp/templates/socialaccount/signup.html
+++ b/ihp/templates/socialaccount/signup.html
@@ -1,0 +1,56 @@
+{% extends "socialaccount/base.html" %}
+
+{% load i18n %}
+{% load bootstrap_tags %}
+
+{% block title %}{% trans "Signup" %}{% endblock %}
+
+{% block body_outer %}
+    <h1>{% trans "Sign Up" %}</h1>
+
+<p>{% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to
+{{site_name}}. As a final step, please complete the following form:{% endblocktrans %}</p>
+
+<form id="signup_form" method="post" action="{% url 'socialaccount_signup' %}">
+  {% csrf_token %}
+  {{ form|as_bootstrap }}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
+  <div class="form-actions">
+      <button class="btn btn-primary" type="submit">{% trans "Sign Up" %}</button>
+  </div>
+</form>
+
+{% endblock %}
+
+{% block extra_script %}
+    {{ block.super }}
+    <script type="text/javascript">
+        $(document).ready(function() {
+            $('#id_username').focus();
+        });
+
+
+        $(document).ready(function() {
+            $("div.form-actions button[type=submit]").click(function(event) {
+                const allowedCharacters = /^[a-z\-A-Z]*$/;
+                const first_name_input = $("#id_first_name");
+                const last_name_input = $("#id_last_name");
+                const first_name_ok = allowedCharacters.test(first_name_input.val());
+                const last_name_ok = allowedCharacters.test(last_name_input.val());
+                const error_message = "name can consist only of letters and a dash";
+                if (!first_name_ok) {
+                    first_name_input[0].setCustomValidity("First " + error_message);
+                } else {
+                    first_name_input[0].setCustomValidity("");
+                }
+                if (!last_name_ok) {
+                    last_name_input[0].setCustomValidity("Last " + error_message);
+                } else {
+                    last_name_input[0].setCustomValidity("");
+                }
+            });
+        });
+    </script>
+{% endblock %}

--- a/ihp/urls.py
+++ b/ihp/urls.py
@@ -25,8 +25,7 @@ from ihp.content.views import (terms_of_use_view,
                                about_us_content_view,
                                contact_us_content_view,
                                faq_page_view,
-                               documentation_page_view,
-                               SignupView)
+                               documentation_page_view)
 
 import geonode.urls
 
@@ -61,7 +60,4 @@ urlpatterns = [
                 url(r'^contact-us$',
                     contact_us_content_view,
                     name='contact-us'),
-                url(r'^account/signup/$',
-                    SignupView.as_view(),
-                    name="account_signup"),
               ] + geonode.urls.urlpatterns


### PR DESCRIPTION
This PR adds support for registering and authenticating users with their linkedin and facebook accounts. It fixes #46.

It is using a recent geonode version, where Oauth2 client support has been added and where [django-allauth]() has been introduced to manage user accounts.

Due to the different auth handling with the newer geonode version, there are some substantial changes in this PR other than just wiring up linkedin and facebook as auth providers:

- patching of forms and views in the app registry (`ihp/__init__.py`) is not needed anymore. The signup form was reimplemented in `ihp/content/forms.py` and hooked up via django-allauth's extensibility mechanisms. A nice plus is that django-allauth handles username creation seamlessly, even with the changes in the signup form;
- e-mail related templates were deleted, as their geonode default implementations suffice.

Some screenshots to show the Oauth providers:
![ihp_login](https://user-images.githubusercontent.com/732010/33183942-0beaa100-d072-11e7-9993-4683cebae4f6.png)
![ihp_register_user](https://user-images.githubusercontent.com/732010/33183948-1230d796-d072-11e7-8549-7fd6abaaa427.png)
