### PR TITLE
Allow signin with email

### DIFF
--- a/ihp/people/tests/test_login.py
+++ b/ihp/people/tests/test_login.py
@@ -76,7 +76,7 @@ class TestUserLogin(TestCase):
 
     def test_login_success_with_email(self):
         """
-        Test for sign in success with valid email and assword
+        Test for sign in success with valid email and password
         """
         response = self.client.post(
             self.login_url, data=self.valid_email_and_password_form_data)

--- a/ihp/people/tests/test_login.py
+++ b/ihp/people/tests/test_login.py
@@ -80,6 +80,8 @@ class TestUserLogin(TestCase):
             self.login_url, data=self.invalid_email_form_data)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['user'].is_authenticated)
+        self.assertEqual(response.context['form'].errors['__all__'],
+                         ['The e-mail address and/or password you specified are not correct.'])
 
     def test_failed_login_with_invalid_username(self):
         """
@@ -89,6 +91,8 @@ class TestUserLogin(TestCase):
             self.login_url, data=self.invalid_username_form_data)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['user'].is_authenticated)
+        self.assertEqual(response.context['form'].errors['__all__'],
+                         ['The username and/or password you specified are not correct.'])
 
     def test_failed_login_with_invalid_password(self):
         """
@@ -98,6 +102,8 @@ class TestUserLogin(TestCase):
             self.login_url, data=self.invalid_password_form_data)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['user'].is_authenticated)
+        self.assertEqual(response.context['form'].errors['__all__'],
+                         ['The e-mail address and/or password you specified are not correct.'])
 
     def test_failed_login_with_no_login_credentials(self):
         """
@@ -107,3 +113,7 @@ class TestUserLogin(TestCase):
             self.login_url, data={})
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['user'].is_authenticated)
+        self.assertEqual(response.context['form'].errors['login'], [
+            'This field is required.'])
+        self.assertEqual(response.context['form'].errors['password'], [
+            'This field is required.'])

--- a/ihp/people/tests/test_login.py
+++ b/ihp/people/tests/test_login.py
@@ -1,0 +1,81 @@
+import json
+
+import pytest
+from django.test import TestCase
+from django.urls import reverse
+
+from ihp.people.models import IHPProfile
+
+
+@pytest.mark.django_db
+class TestUserRegistration(TestCase):
+    def setUp(self):
+        self.user = IHPProfile.objects.create_user(**{
+            "username": "valid-username",
+            "email": "test@email.com",
+            "password": "valid-password",
+            "is_active": True
+        })
+
+        self.login_url = reverse('account_login')
+
+        self.valid_email_and_password = {
+            "login": "test@email.com",
+            "password": "valid-password"
+        }
+
+        self.valid_username_and_password = {
+            "login": "valid-username",
+            "password": "valid-password"
+        }
+
+        self.invalid_email = {
+            "login": "incorect-email@mail.com",
+            "password": "valid-password"
+        }
+
+        self.invalid_username = {
+            "login": "incorect-username",
+            "password": "valid-password"
+        }
+
+        self.password = {
+            "login": "test@email.com",
+            "password": "incorrect-password"
+        }
+
+    def test_login_success_with_email(self):
+        response = self.client.post(
+            self.login_url, data=self.valid_email_and_password)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.context['user'].is_authenticated)
+
+    def test_login_success_with_username(self):
+        response = self.client.post(
+            self.login_url, data=self.valid_username_and_password)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.context['user'].is_authenticated)
+
+    def test_failed_login_with_incorrect_email(self):
+        response = self.client.post(
+            self.login_url, data=self.invalid_email)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['user'].is_authenticated)
+
+    def test_failed_login_with_incorrect_username(self):
+        response = self.client.post(
+            self.login_url, data=self.invalid_username)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['user'].is_authenticated)
+
+    def test_failed_login_with_incorrect_password(self):
+        response = self.client.post(
+            self.login_url, data=self.password)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['user'].is_authenticated)
+
+    def test_failed_login_with_no_login_credentials(self):
+        response = self.client.post(
+            self.login_url, data={})
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['user'].is_authenticated)

--- a/ihp/people/tests/test_login.py
+++ b/ihp/people/tests/test_login.py
@@ -67,7 +67,7 @@ class TestUserLogin(TestCase):
         }
 
         self.invalid_username_form_data = {
-            "login": "incorect-username",
+            "login": "incorrect-username",
             "password": "valid-password"
         }
 

--- a/ihp/people/tests/test_login.py
+++ b/ihp/people/tests/test_login.py
@@ -24,8 +24,6 @@ when you run "manage.py test".
 
 """
 
-import json
-
 import pytest
 from django.test import TestCase
 from django.urls import reverse

--- a/ihp/people/tests/test_login.py
+++ b/ihp/people/tests/test_login.py
@@ -1,23 +1,3 @@
-# -*- coding: utf-8 -*-
-#########################################################################
-#
-# Copyright (C) 2016 OSGeo
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-#########################################################################
-
 """
 This file demonstrates writing tests using the unittest module. These will pass
 when you run "manage.py test".

--- a/ihp/people/tests/test_login.py
+++ b/ihp/people/tests/test_login.py
@@ -8,7 +8,7 @@ from ihp.people.models import IHPProfile
 
 
 @pytest.mark.django_db
-class TestUserRegistration(TestCase):
+class TestUserLogin(TestCase):
     def setUp(self):
         self.user = IHPProfile.objects.create_user(**{
             "username": "valid-username",

--- a/ihp/people/tests/test_login.py
+++ b/ihp/people/tests/test_login.py
@@ -1,3 +1,29 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+"""
+This file demonstrates writing tests using the unittest module. These will pass
+when you run "manage.py test".
+
+"""
+
 import json
 
 import pytest
@@ -10,6 +36,11 @@ from ihp.people.models import IHPProfile
 @pytest.mark.django_db
 class TestUserLogin(TestCase):
     def setUp(self):
+        """
+        Setup tests to for user login/sign in
+        """
+
+        # create a user account
         self.user = IHPProfile.objects.create_user(**{
             "username": "valid-username",
             "email": "test@email.com",
@@ -17,64 +48,83 @@ class TestUserLogin(TestCase):
             "is_active": True
         })
 
+        # get user login route
         self.login_url = reverse('account_login')
 
-        self.valid_email_and_password = {
+        self.valid_email_and_password_form_data = {
             "login": "test@email.com",
             "password": "valid-password"
         }
 
-        self.valid_username_and_password = {
+        self.valid_username_and_password_form_data = {
             "login": "valid-username",
             "password": "valid-password"
         }
 
-        self.invalid_email = {
+        self.invalid_email_form_data = {
             "login": "incorect-email@mail.com",
             "password": "valid-password"
         }
 
-        self.invalid_username = {
+        self.invalid_username_form_data = {
             "login": "incorect-username",
             "password": "valid-password"
         }
 
-        self.password = {
+        self.invalid_password_form_data = {
             "login": "test@email.com",
             "password": "incorrect-password"
         }
 
     def test_login_success_with_email(self):
+        """
+        Test for sign in success with valid email and assword
+        """
         response = self.client.post(
-            self.login_url, data=self.valid_email_and_password)
+            self.login_url, data=self.valid_email_and_password_form_data)
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.context['user'].is_authenticated)
 
     def test_login_success_with_username(self):
+        """
+        Test for sign in success with valid username and password
+        """
         response = self.client.post(
-            self.login_url, data=self.valid_username_and_password)
+            self.login_url, data=self.valid_username_and_password_form_data)
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.context['user'].is_authenticated)
 
-    def test_failed_login_with_incorrect_email(self):
+    def test_failed_login_with_invalid_email(self):
+        """
+        Test sign in failure with invalid email
+        """
         response = self.client.post(
-            self.login_url, data=self.invalid_email)
+            self.login_url, data=self.invalid_email_form_data)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['user'].is_authenticated)
 
-    def test_failed_login_with_incorrect_username(self):
+    def test_failed_login_with_invalid_username(self):
+        """
+        Test sign in failure with invalid username
+        """
         response = self.client.post(
-            self.login_url, data=self.invalid_username)
+            self.login_url, data=self.invalid_username_form_data)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['user'].is_authenticated)
 
-    def test_failed_login_with_incorrect_password(self):
+    def test_failed_login_with_invalid_password(self):
+        """
+        Test sign in failure with invalid password
+        """
         response = self.client.post(
-            self.login_url, data=self.password)
+            self.login_url, data=self.invalid_password_form_data)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context['user'].is_authenticated)
 
     def test_failed_login_with_no_login_credentials(self):
+        """
+        Test sign in failure with no login credentials
+        """
         response = self.client.post(
             self.login_url, data={})
         self.assertEqual(response.status_code, 200)

--- a/ihp/settings.py
+++ b/ihp/settings.py
@@ -93,6 +93,9 @@ LICENSES = {
 AUTH_USER_MODEL = os.getenv('AUTH_USER_MODEL', 'ihp_people.IHPProfile')
 AUTH_USER_AUTOCOMPLETE = os.getenv('AUTH_USER_AUTOCOMPLETE', 'IHPProfileProfileAutocomplete')
 
+# allow registered users to sign in using their username or email
+ACCOUNT_AUTHENTICATION_METHOD = "username_email"
+
 # prevent signing up by default
 ACCOUNT_OPEN_SIGNUP = True
 ACCOUNT_EMAIL_REQUIRED = True


### PR DESCRIPTION
### What does the PR do?
- Allows registered users to sign in using their email or username

### Changes made.
- Set an allauth settings flag to allow registered users to sign in using their email or username