### PR TITLE
Add request_to_join_group to django admin

### DIFF
--- a/ihp/people/admin.py
+++ b/ihp/people/admin.py
@@ -36,6 +36,7 @@ class IHPProfileAdmin(ProfileAdmin):
         (_('Permissions'), {'fields': ('approved', 'is_active', 'is_staff', 'is_superuser',
                                        'groups')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
+        (_('Group(s) you want to join'), {'fields': ('request_to_join_group',)}),
         (_('Extended profile'), {'fields': ('organization', 'profile',
                                             'position', 'voice', 'fax',
                                             'delivery', 'city', 'area',


### PR DESCRIPTION
### What does the PR do?
- Adds Group(s) you want to join to the Django admin interface

### Changes made
- Added a new fieldset to `IHPProfileAdmin` class