### PR TITLE
Issue 263 add request to join group to profile admin interface

### DIFF
--- a/ihp/content/adapters.py
+++ b/ihp/content/adapters.py
@@ -17,6 +17,7 @@ from django.http import HttpResponseRedirect
 from django.utils.module_loading import import_string
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
+from django.db.models import Q
 
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.utils import user_field
@@ -122,10 +123,12 @@ class UnescoLocalAccountAdapter(LocalAccountAdapter):
             user_field(user, 'position', position or None)
             user_field(user, 'country', country or None)
 
-            groups = GroupProfile.objects.filter(pk__in=[
-                # sanitize user input before saving
-                request for request in request_to_join_group if request.isdigit()
-            ], access="public")
+            groups = GroupProfile.objects.filter(
+                Q(access=GroupProfile.GROUP_CHOICES[0][0]) | Q(access=GroupProfile.GROUP_CHOICES[1][0]),
+                pk__in=[
+                    # sanitize user input before saving
+                    request for request in request_to_join_group if request.isdigit()
+                ])
 
             user.request_to_join_group.add(*groups)
             user.save()


### PR DESCRIPTION
### What does the PR do?
- Allows 'public-invite' groups profiles to be added under `request_to_join_group` during registration