### PR TITLE
Fix missing text for select2 'request_to_join_group'

### DIFF
--- a/ihp/content/adapters.py
+++ b/ihp/content/adapters.py
@@ -62,13 +62,7 @@ class UnescoLocalAccountAdapter(LocalAccountAdapter):
         return recommendation
 
     def clean_request_to_join_group(self, request_to_join_group):
-        groups = GroupProfile.objects.filter(
-            Q(access=GroupProfile.GROUP_CHOICES[0][0]) | Q(access=GroupProfile.GROUP_CHOICES[1][0]),
-            pk__in=[
-                # sanitize user input before saving
-                request for request in request_to_join_group if request.isdigit()
-            ])
-        return groups
+        return request_to_join_group
 
     def populate_username(self, request, user):
         # validate the already generated username with django validation

--- a/ihp/content/adapters.py
+++ b/ihp/content/adapters.py
@@ -17,7 +17,6 @@ from django.http import HttpResponseRedirect
 from django.utils.module_loading import import_string
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
-from django.db.models import Q
 
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.utils import user_field
@@ -26,7 +25,6 @@ from allauth.account.utils import user_username
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 
 from geonode.people.adapters import LocalAccountAdapter
-from geonode.groups.models import GroupProfile
 
 logger = logging.getLogger(__name__)
 

--- a/ihp/content/adapters.py
+++ b/ihp/content/adapters.py
@@ -124,7 +124,6 @@ class UnescoLocalAccountAdapter(LocalAccountAdapter):
             user_field(user, 'organization', organization or None)
             user_field(user, 'position', position or None)
             user_field(user, 'country', country or None)
-
-            user.request_to_join_group.add(*recommendation)
+            user.request_to_join_group.add(*request_to_join_group)
             user.save()
         return user

--- a/ihp/content/forms.py
+++ b/ihp/content/forms.py
@@ -26,7 +26,6 @@ class UnescoLocalAccountSignupForm(account_forms.SignupForm):
 
     def clean_request_to_join_group(self):
         request_to_join_group = self.cleaned_data["request_to_join_group"]
-        self.fields["request_to_join_group"].initial = ['hahah']
 
         groups = GroupProfile.objects.filter(
             Q(access=GroupProfile.GROUP_CHOICES[0][0]) | Q(access=GroupProfile.GROUP_CHOICES[1][0]),
@@ -35,8 +34,8 @@ class UnescoLocalAccountSignupForm(account_forms.SignupForm):
                 request for request in request_to_join_group if request.isdigit()
             ])
 
-        request_to_join_group = get_adapter().clean_request_to_join_group(request_to_join_group)
-        self.cleaned_data["request_to_join_group"] = groups
+        request_to_join_group = get_adapter().clean_request_to_join_group(groups)
+        self.cleaned_data["request_to_join_group"] = request_to_join_group
         return self.cleaned_data["request_to_join_group"]
 
 

--- a/ihp/content/forms.py
+++ b/ihp/content/forms.py
@@ -10,6 +10,7 @@ from taggit.forms import TagField
 
 from geonode.groups.models import GroupProfile
 from geonode.base.enumerations import COUNTRIES
+from django.db.models import Q
 
 
 class UnescoLocalAccountSignupForm(account_forms.SignupForm):
@@ -22,6 +23,21 @@ class UnescoLocalAccountSignupForm(account_forms.SignupForm):
         recommendation = self.cleaned_data["recommendation"]
         recommendation = get_adapter().clean_recommendation(recommendation)
         return self.cleaned_data["recommendation"]
+
+    def clean_request_to_join_group(self):
+        request_to_join_group = self.cleaned_data["request_to_join_group"]
+        self.fields["request_to_join_group"].initial = ['hahah']
+
+        groups = GroupProfile.objects.filter(
+            Q(access=GroupProfile.GROUP_CHOICES[0][0]) | Q(access=GroupProfile.GROUP_CHOICES[1][0]),
+            pk__in=[
+                # sanitize user input before saving
+                request for request in request_to_join_group if request.isdigit()
+            ])
+
+        request_to_join_group = get_adapter().clean_request_to_join_group(request_to_join_group)
+        self.cleaned_data["request_to_join_group"] = groups
+        return self.cleaned_data["request_to_join_group"]
 
 
 class UnescoSocialAccountSignupForm(socialaccount_forms.SignupForm):

--- a/ihp/people/templatetags/modify_field_text.py
+++ b/ihp/people/templatetags/modify_field_text.py
@@ -1,0 +1,14 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter(name=u'modify_field_title')
+def modify_field_title(form):
+    """
+    Modifies form request_to_join_group when an error occurs to
+    prevent rendering group id without title in select2
+    """
+    new_data = form.data.copy()
+    new_data[u'request_to_join_group'] = ''
+    form.data = new_data

--- a/ihp/templates/account/signup.html
+++ b/ihp/templates/account/signup.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load bootstrap_tags %}
 {% load account socialaccount %}
+{% load modify_field_text %}
 
 {% block head_title %}{% trans "Sign up" %}{% endblock %}
 {% block title %}{% trans "Sign up" %}{% endblock %}
@@ -21,6 +22,10 @@
                 <hr>
             {% endif %}
             <p>{% trans "Create a new local account" %}</p>
+            {% if form.errors %}
+              <!-- call the commented line below to run the "add_field_name" without returning rendering it's value -->
+              <!-- {{ form | modify_field_title }} -->
+            {%  endif %}
             <form id="signup_form" method="post" action="{% url "account_signup" %}" autocapitalize="off" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
                 <fieldset>
                     {% csrf_token %}
@@ -68,6 +73,13 @@
         }
       });
     });
+    {% if form.errors %}
+    $(document).ready(function(){
+      {% for item in form.cleaned_data.request_to_join_group %}
+      $('#id_request_to_join_group').append('<option value="{{item.pk}}" selected="">{{item.title}}</option>');
+      {% endfor %}
+    })
+    {% endif %}
 
     $('#id_request_to_join_group').select2(
     {


### PR DESCRIPTION
### what does the PR do
- Fixes issue causing select-2's "select groups to join" to only show the group_profile ID instead of title

### Changes made
- Added allauth cleaning methods to sanitize data and convert "group_profile" ID(s) into model objects making them available in forms.
- Created a Django filter to modify django-taggit form fields 
- Used conditional rendered javascript to append options to select-2's multiple choice field with values as object ID(s) and inner-html as titles